### PR TITLE
Enable customized concurrency

### DIFF
--- a/multirun/main.go
+++ b/multirun/main.go
@@ -45,7 +45,7 @@ type command struct {
 
 type instructions struct {
 	Commands []command `json:"commands"`
-	Parallel bool      `json:"parallel"`
+	Jobs     int       `json:"jobs"`
 	Quiet    bool      `json:"quiet"`
 }
 
@@ -76,7 +76,7 @@ func (a arguments) run(ctx context.Context) (int, error) {
 		stdoutSink: os.Stdout,
 		stderrSink: os.Stderr,
 		args:       a.args,
-		parallel:   instr.Parallel,
+		jobs:       instr.Jobs,
 		quiet:      instr.Quiet,
 	}
 	err = m.run(ctx)

--- a/multirun/multirun.go
+++ b/multirun/multirun.go
@@ -10,49 +10,99 @@ type multirun struct {
 	commands               []command
 	stdoutSink, stderrSink io.Writer
 	args                   []string
-	parallel               bool
+	jobs                   int
 	quiet                  bool
 }
 
 func (m multirun) run(ctx context.Context) error {
-	if m.parallel {
-		errs := make(chan error)
-		for _, cmd := range m.commands {
-			p := process{
-				tag:        cmd.Tag,
-				path:       cmd.Path,
-				stdoutSink: m.stdoutSink,
-				stderrSink: m.stderrSink,
-				args:       m.args,
-				addTag:     true,
-			}
-			go func() {
-				errs <- p.run(ctx)
-			}()
+	// minimum concurrency is 1, which is sequential
+	if m.jobs < 0 {
+		return fmt.Errorf("jobs must be at least 0")
+	}
+
+	if m.jobs == 0 {
+		return m.unboundedExecution(ctx)
+	}
+
+	return m.boundedExecution(ctx)
+}
+
+// unboundedExecution execute multiple commands without concurrency limit
+func (m multirun) unboundedExecution(ctx context.Context) error {
+	errs := make(chan error)
+
+	for _, cmd := range m.commands {
+		p := process{
+			tag:        cmd.Tag,
+			path:       cmd.Path,
+			stdoutSink: m.stdoutSink,
+			stderrSink: m.stderrSink,
+			args:       m.args,
+			addTag:     true,
 		}
-		var firstError error
-		for range m.commands {
-			if err := <-errs; firstError == nil {
-				firstError = err
-			}
-		}
-		return firstError
-	} else {
-		for _, cmd := range m.commands {
-			p := process{
-				tag:        cmd.Tag,
-				path:       cmd.Path,
-				stdoutSink: m.stdoutSink,
-				stderrSink: m.stderrSink,
-				args:       m.args,
-			}
-			if !m.quiet {
-				fmt.Fprintf(m.stderrSink, "Running %s\n", cmd.Tag)
-			}
-			if err := p.run(ctx); err != nil {
-				return err
-			}
+
+		go func() {
+			errs <- p.run(ctx)
+		}()
+	}
+
+	var firstError error
+	for range m.commands {
+		if err := <-errs; firstError == nil {
+			firstError = err
 		}
 	}
-	return nil
+
+	return firstError
+}
+
+// boundedExecution execute multiple commands using a sized worker pool
+func (m multirun) boundedExecution(ctx context.Context) error {
+	// errs should be buffered to avoid blocking
+	// when len(m.commands) > m.jobs
+	errs := make(chan error, len(m.commands))
+	commands := make(chan command)
+
+	// start worker pool
+	for w := 0; w < m.jobs; w++ {
+		go m.spawnWorker(ctx, commands, errs)
+	}
+
+	// send command to worker pool
+	for _, cmd := range m.commands {
+		commands <- cmd
+	}
+	close(commands)
+
+	var firstError error
+	for range m.commands {
+		if err := <-errs; firstError == nil {
+			firstError = err
+		}
+	}
+
+	return firstError
+}
+
+func (m multirun) spawnWorker(ctx context.Context, commands <-chan command, errs chan<- error) {
+	for cmd := range commands {
+		p := process{
+			tag:        cmd.Tag,
+			path:       cmd.Path,
+			stdoutSink: m.stdoutSink,
+			stderrSink: m.stderrSink,
+			args:       m.args,
+		}
+
+		// when execute concurrently, tag should be added
+		if m.jobs > 1 {
+			p.addTag = true
+		}
+
+		if !m.quiet {
+			fmt.Fprintf(m.stderrSink, "Running %s\n", cmd.Tag)
+		}
+
+		errs <- p.run(ctx)
+	}
 }


### PR DESCRIPTION
Provide a way for user to customize concurrency of tasks to be executed.

This is extremely relevant when you try to use multirun to execute
a larget number of targets on a powerful machine, each affecting a
weaker downstream machine. E.g. using this to push multiple container
images could easily overwhelm the container registry, or reach a
ratelimit enforced by a cloud vendor.

Replace boolean 'parallel' attribute with int 'jobs' attribute which
determine the maximum concurrency of multirun. 'jobs' default value is
set to 1 which is the same with sequential execution.