### PR TITLE
Give goimports access to the go binary of the rules_go sdk

### DIFF
--- a/goimports/runner.bash.template
+++ b/goimports/runner.bash.template
@@ -3,9 +3,12 @@
 set -euo pipefail
 
 GOIMPORTS_SHORT_PATH=@@GOIMPORTS_SHORT_PATH@@
+GO_SHORT_PATH=@@GO_SHORT_PATH@@
 ARGS=@@ARGS@@
 PREFIX_DIR_PATH=@@PREFIX_DIR_PATH@@
 PREFIX_BASE_NAME=@@PREFIX_BASE_NAME@@
+
+GO_BIN_DIR=$(dirname $(readlink ${GO_SHORT_PATH}))
 
 mkdir -p "src/$PREFIX_DIR_PATH"
 ln -snf "$BUILD_WORKSPACE_DIRECTORY" "src/$PREFIX_DIR_PATH/$PREFIX_BASE_NAME"
@@ -17,4 +20,4 @@ trap "rm -rf '${GOCACHE}'" EXIT
 goimports_short_path=$(readlink "$GOIMPORTS_SHORT_PATH")
 CURDIR="$GOPATH/src/$PREFIX_DIR_PATH/$PREFIX_BASE_NAME"
 cd "$CURDIR"
-/usr/bin/env -i GOPATH="$GOPATH" GOCACHE="${GOCACHE}" PATH="$PATH" PWD="$CURDIR" "$goimports_short_path" "${ARGS[@]}" $(find . -type f -name  '*.go' -not -path './bazel-*' @@EXCLUDE_PATHS@@ @@EXCLUDE_FILES@@) "$@"
+/usr/bin/env -i GOPATH="$GOPATH" GOCACHE="${GOCACHE}" PATH="$PATH:$GO_BIN_DIR" PWD="$CURDIR" "$goimports_short_path" "${ARGS[@]}" $(find . -type f -name  '*.go' -not -path './bazel-*' @@EXCLUDE_PATHS@@ @@EXCLUDE_FILES@@) "$@"


### PR DESCRIPTION
Give it the go binary from the golang sdk selected via rules_go.
This allows running the goimports rule on a system where golang is not
installed on the underlying host or container.

Fixes #4 