### PR TITLE
Signal processes to stop on error and don't start new ones

### DIFF
--- a/multirun/test/BUILD.bazel
+++ b/multirun/test/BUILD.bazel
@@ -130,12 +130,12 @@ multirun(
         ":command_echo_2",
         ":command_echo_1",
     ],
-    parallel = True,
+    jobs = 0,
 )
 
 multirun(
     name = "multirun_parallel_tagged_success",
-    parallel = True,
+    jobs = 0,
     tagged_commands = {
         ":command_echo_2": "echo-2",
         ":command_echo_1": "echo-1",
@@ -182,10 +182,10 @@ multirun(
     name = "multirun_parallel_failure",
     commands = [
         ":command_echo_2",
-        ":command_exit",
-        ":command_echo_3",
+        ":command_sleep_and_exit_0",
+        ":command_sleep_and_exit_5",
     ],
-    parallel = True,
+    jobs = 0,
 )
 
 command(
@@ -269,22 +269,30 @@ sh_binary(
 multirun(
     name = "multirun_signal_handling",
     commands = [
-        ":command_sleep_and_exit",
+        ":command_sleep_and_exit_0",
     ],
 )
 
 multirun(
     name = "multirun_parallel_signal_handling",
     commands = [
-        ":command_sleep_and_exit",
+        ":command_sleep_and_exit_0",
     ],
-    parallel = True,
+    jobs = 0,
 )
 
 command(
-    name = "command_sleep_and_exit",
+    name = "command_sleep_and_exit_0",
     arguments = [
-        "4",
+        "4", "0",
+    ],
+    command = ":sleep_and_exit",
+)
+
+command(
+    name = "command_sleep_and_exit_5",
+    arguments = [
+        "1", "5",
     ],
     command = ":sleep_and_exit",
 )

--- a/multirun/test/expected_parallel_failure.txt
+++ b/multirun/test/expected_parallel_failure.txt
@@ -1,5 +1,6 @@
 [//multirun/test:command_echo_2] command_2 a
 [//multirun/test:command_echo_2] command_2 b
 [//multirun/test:command_echo_2] command_2 c
-[//multirun/test:command_echo_3] command_3 a
-[//multirun/test:command_exit] exiting 5
+[//multirun/test:command_sleep_and_exit_0] sleeping before exiting 4
+[//multirun/test:command_sleep_and_exit_5] exiting: 5
+[//multirun/test:command_sleep_and_exit_5] sleeping before exiting 1

--- a/multirun/test/expected_parallel_sigint.txt
+++ b/multirun/test/expected_parallel_sigint.txt
@@ -1,5 +1,5 @@
 RAK>>running multirun/test/multirun_parallel_signal_handling.bash
 RAK>>sleeping 2
-[//multirun/test:command_sleep_and_exit] sleeping before exiting 4
+[//multirun/test:command_sleep_and_exit_0] sleeping before exiting 4
 RAK>>killing with signal SIGINT
 RAK>>done

--- a/multirun/test/expected_parallel_sigterm.txt
+++ b/multirun/test/expected_parallel_sigterm.txt
@@ -1,5 +1,5 @@
 RAK>>running multirun/test/multirun_parallel_signal_handling.bash
 RAK>>sleeping 2
-[//multirun/test:command_sleep_and_exit] sleeping before exiting 4
+[//multirun/test:command_sleep_and_exit_0] sleeping before exiting 4
 RAK>>killing with signal SIGTERM
 RAK>>done

--- a/multirun/test/expected_sigint.txt
+++ b/multirun/test/expected_sigint.txt
@@ -1,6 +1,6 @@
 RAK>>running multirun/test/multirun_signal_handling.bash
 RAK>>sleeping 2
-Running //multirun/test:command_sleep_and_exit
+Running //multirun/test:command_sleep_and_exit_0
 sleeping before exiting 4
 RAK>>killing with signal SIGINT
 RAK>>done

--- a/multirun/test/expected_sigterm.txt
+++ b/multirun/test/expected_sigterm.txt
@@ -1,6 +1,6 @@
 RAK>>running multirun/test/multirun_signal_handling.bash
 RAK>>sleeping 2
-Running //multirun/test:command_sleep_and_exit
+Running //multirun/test:command_sleep_and_exit_0
 sleeping before exiting 4
 RAK>>killing with signal SIGTERM
 RAK>>done

--- a/multirun/test/sleep_and_exit.sh
+++ b/multirun/test/sleep_and_exit.sh
@@ -2,4 +2,5 @@
 
 echo "sleeping before exiting $1"
 sleep "$1"
-echo "exiting"
+echo "exiting: $2"
+exit "$2"


### PR DESCRIPTION
Closes #7.

Bug was introduced in https://github.com/ash2k/bazel-tools/pull/1: new jobs were being started even if an error has occurred.

This PR brings back the old correct behavior and also changes the behavior to send `SIGTERM` to currently running jobs on error. This is how it works if the main process receives `SIGTERM`, so it makes sense to be consistent with that.

FYI @sluongng 