### PR TITLE
Add addTag override

### DIFF
--- a/multirun/def.bzl
+++ b/multirun/def.bzl
@@ -83,6 +83,7 @@ def _multirun_impl(ctx):
         commands = commands,
         jobs = jobs,
         quiet = ctx.attr.quiet,
+        addTag = ctx.attr.add_tag,
     )
     ctx.actions.write(
         output = instructions_file,
@@ -130,6 +131,10 @@ _multirun = rule(
         "parallel": attr.bool(
             default = False,
             doc = "Deprecated, please use 'jobs' instad.If true, targets will be run in parallel, not in the specified order",
+        ),
+        "add_tag": attr.bool(
+            default = True,
+            doc = "Include the tool in the output lines, only for parallel output",
         ),
         "quiet": attr.bool(
             default = False,

--- a/multirun/main.go
+++ b/multirun/main.go
@@ -47,6 +47,7 @@ type instructions struct {
 	Commands []command `json:"commands"`
 	Jobs     int       `json:"jobs"`
 	Quiet    bool      `json:"quiet"`
+	AddTag   bool      `json:"addTag"`
 }
 
 type arguments struct {
@@ -78,6 +79,7 @@ func (a arguments) run(ctx context.Context) (int, error) {
 		args:       a.args,
 		jobs:       instr.Jobs,
 		quiet:      instr.Quiet,
+		addTag:     instr.AddTag,
 	}
 	err = m.run(ctx)
 	if err != nil {

--- a/multirun/multirun.go
+++ b/multirun/multirun.go
@@ -13,6 +13,7 @@ type multirun struct {
 	args                   []string
 	jobs                   int
 	quiet                  bool
+	addTag                 bool
 }
 
 func (m multirun) run(ctx context.Context) error {
@@ -41,7 +42,7 @@ func (m multirun) unboundedExecution(ctx context.Context) error {
 			stdoutSink: m.stdoutSink,
 			stderrSink: m.stderrSink,
 			args:       m.args,
-			addTag:     true,
+			addTag:     m.addTag,
 		}
 
 		go func() {
@@ -117,7 +118,7 @@ func (m multirun) spawnWorker(ctx context.Context, commands <-chan command) erro
 
 		// when execute concurrently, tag should be added
 		if m.jobs > 1 {
-			p.addTag = true
+			p.addTag = m.addTag
 		}
 
 		if !m.quiet {

--- a/multirun/test/BUILD.bazel
+++ b/multirun/test/BUILD.bazel
@@ -75,6 +75,22 @@ sh_test(
 )
 
 sh_test(
+    name = "test_multirun_no_tag",
+    srcs = ["test_compare_content.sh"],
+    args = [
+        # Sort the output for deterministic comparison; order doesn't matter as long as all the expected lines are
+        # there.
+        "'$(location :multirun_parallel_no_tag) | sort'",
+        "0",
+        "$(location expected_parallel_no_tag.txt)",
+    ],
+    data = [
+        "expected_parallel_no_tag.txt",
+        ":multirun_parallel_no_tag",
+    ],
+)
+
+sh_test(
     name = "test_multirun_parallel_tagged_success",
     srcs = ["test_compare_content.sh"],
     args = [
@@ -126,6 +142,16 @@ multirun(
 
 multirun(
     name = "multirun_parallel_success",
+    commands = [
+        ":command_echo_2",
+        ":command_echo_1",
+    ],
+    jobs = 0,
+)
+
+multirun(
+    name = "multirun_parallel_no_tag",
+    add_tag = False,
     commands = [
         ":command_echo_2",
         ":command_echo_1",

--- a/multirun/test/expected_parallel_no_tag.txt
+++ b/multirun/test/expected_parallel_no_tag.txt
@@ -1,0 +1,5 @@
+command_1 a
+command_1 b
+command_2 a
+command_2 b
+command_2 c


### PR DESCRIPTION
This allows you to disable the prefix from parallel commands so:

```
[foo]: output
```

Is just produced as:

```
output
```

This is useful when you want to run multiple tools in parallel and parse
the output, and don't particularly care which tool produced the line.