### PR TITLE
Add `stopOnError` to multirun

### DIFF
--- a/multirun/def.bzl
+++ b/multirun/def.bzl
@@ -84,6 +84,7 @@ def _multirun_impl(ctx):
         jobs = jobs,
         quiet = ctx.attr.quiet,
         addTag = ctx.attr.add_tag,
+        stopOnError = ctx.attr.stop_on_error,
     )
     ctx.actions.write(
         output = instructions_file,
@@ -139,6 +140,10 @@ _multirun = rule(
         "quiet": attr.bool(
             default = False,
             doc = "Limit output where possible",
+        ),
+        "stop_on_error": attr.bool(
+            default = True,
+            doc = "Stop the command chain when error occurs",
         ),
         "_bash_runfiles": attr.label(
             default = Label("@bazel_tools//tools/bash/runfiles"),

--- a/multirun/main.go
+++ b/multirun/main.go
@@ -44,10 +44,11 @@ type command struct {
 }
 
 type instructions struct {
-	Commands []command `json:"commands"`
-	Jobs     int       `json:"jobs"`
-	Quiet    bool      `json:"quiet"`
-	AddTag   bool      `json:"addTag"`
+	Commands    []command `json:"commands"`
+	Jobs        int       `json:"jobs"`
+	Quiet       bool      `json:"quiet"`
+	AddTag      bool      `json:"addTag"`
+	StopOnError bool      `json:"stopOnError"`
 }
 
 type arguments struct {
@@ -73,13 +74,14 @@ func (a arguments) run(ctx context.Context) (int, error) {
 		return 0, err
 	}
 	m := multirun{
-		commands:   instr.Commands,
-		stdoutSink: os.Stdout,
-		stderrSink: os.Stderr,
-		args:       a.args,
-		jobs:       instr.Jobs,
-		quiet:      instr.Quiet,
-		addTag:     instr.AddTag,
+		commands:    instr.Commands,
+		stdoutSink:  os.Stdout,
+		stderrSink:  os.Stderr,
+		args:        a.args,
+		jobs:        instr.Jobs,
+		quiet:       instr.Quiet,
+		addTag:      instr.AddTag,
+		stopOnError: instr.StopOnError,
 	}
 	err = m.run(ctx)
 	if err != nil {

--- a/multirun/test/BUILD.bazel
+++ b/multirun/test/BUILD.bazel
@@ -59,6 +59,20 @@ sh_test(
 )
 
 sh_test(
+    name = "test_multirun_failure_no_stop",
+    srcs = ["test_compare_content.sh"],
+    args = [
+        "$(location :multirun_failure_no_stop)",
+        "5",
+        "$(location expected_failure_no_stop.txt)",
+    ],
+    data = [
+        "expected_failure_no_stop.txt",
+        ":multirun_failure_no_stop",
+    ],
+)
+
+sh_test(
     name = "test_multirun_parallel_success",
     srcs = ["test_compare_content.sh"],
     args = [
@@ -121,6 +135,23 @@ sh_test(
         ":multirun_parallel_failure",
     ],
 )
+
+sh_test(
+    name = "test_multirun_parallel_failure_no_stop",
+    srcs = ["test_compare_content.sh"],
+    args = [
+        # Sort the output for deterministic comparison; order doesn't matter as long as all the expected lines are
+        # there.
+        "'$(location :multirun_parallel_failure_no_stop) | sort'",
+        "5",
+        "$(location expected_parallel_failure_no_stop.txt)",
+    ],
+    data = [
+        "expected_parallel_failure_no_stop.txt",
+        ":multirun_parallel_failure_no_stop",
+    ],
+)
+
 
 sh_binary(
     name = "exit",
@@ -205,6 +236,16 @@ multirun(
 )
 
 multirun(
+    name = "multirun_failure_no_stop",
+    commands = [
+        ":command_echo_2",
+        ":command_exit",
+        ":command_echo_3",
+    ],
+    stop_on_error = False,
+)
+
+multirun(
     name = "multirun_parallel_failure",
     commands = [
         ":command_echo_2",
@@ -212,6 +253,18 @@ multirun(
         ":command_sleep_and_exit_5",
     ],
     jobs = 0,
+)
+
+multirun(
+    name = "multirun_parallel_failure_no_stop",
+    commands = [
+        ":command_echo_2",
+        ":command_sleep_and_exit_0",
+        ":command_sleep_and_exit_2",
+        ":command_sleep_and_exit_5",
+    ],
+    jobs = 0,
+    stop_on_error = False,
 )
 
 command(
@@ -311,6 +364,14 @@ command(
     name = "command_sleep_and_exit_0",
     arguments = [
         "4", "0",
+    ],
+    command = ":sleep_and_exit",
+)
+
+command(
+    name = "command_sleep_and_exit_2",
+    arguments = [
+        "2", "2",
     ],
     command = ":sleep_and_exit",
 )

--- a/multirun/test/expected_failure_no_stop.txt
+++ b/multirun/test/expected_failure_no_stop.txt
@@ -1,0 +1,8 @@
+Running //multirun/test:command_echo_2
+command_2 a
+command_2 b
+command_2 c
+Running //multirun/test:command_exit
+exiting 5
+Running //multirun/test:command_echo_3
+command_3 a

--- a/multirun/test/expected_parallel_failure_no_stop.txt
+++ b/multirun/test/expected_parallel_failure_no_stop.txt
@@ -1,0 +1,9 @@
+[//multirun/test:command_echo_2] command_2 a
+[//multirun/test:command_echo_2] command_2 b
+[//multirun/test:command_echo_2] command_2 c
+[//multirun/test:command_sleep_and_exit_0] exiting: 0
+[//multirun/test:command_sleep_and_exit_0] sleeping before exiting 4
+[//multirun/test:command_sleep_and_exit_2] exiting: 2
+[//multirun/test:command_sleep_and_exit_2] sleeping before exiting 2
+[//multirun/test:command_sleep_and_exit_5] exiting: 5
+[//multirun/test:command_sleep_and_exit_5] sleeping before exiting 1


### PR DESCRIPTION
This adds `stopOnError` attribute to multirun that allows users to control
whether to stop the command pipeline on first error or to execute the
entire pipeline regardless of errors.
The value is defaulted to `True` to maintain the current behavior of the
multirun command.