### PR TITLE
Fix goimports/runner.bash.template PATH order

### DIFF
--- a/goimports/runner.bash.template
+++ b/goimports/runner.bash.template
@@ -20,4 +20,4 @@ trap "rm -rf '${GOCACHE}'" EXIT
 goimports_short_path=$(readlink "$GOIMPORTS_SHORT_PATH")
 CURDIR="$GOPATH/src/$PREFIX_DIR_PATH/$PREFIX_BASE_NAME"
 cd "$CURDIR"
-/usr/bin/env -i GOPATH="$GOPATH" GOCACHE="${GOCACHE}" PATH="$PATH:$GO_BIN_DIR" PWD="$CURDIR" "$goimports_short_path" "${ARGS[@]}" $(find . -type f -name  '*.go' -not -path './bazel-*' @@EXCLUDE_PATHS@@ @@EXCLUDE_FILES@@) "$@"
+/usr/bin/env -i GOPATH="$GOPATH" GOCACHE="${GOCACHE}" PATH="$GO_BIN_DIR:$PATH" PWD="$CURDIR" "$goimports_short_path" "${ARGS[@]}" $(find . -type f -name  '*.go' -not -path './bazel-*' @@EXCLUDE_PATHS@@ @@EXCLUDE_FILES@@) "$@"


### PR DESCRIPTION
## problem 

I use [asdf](https://github.com/asdf-vm/asdf) to use golang, and I faced this error.

```
 bazelisk run //:goimports 
(12:44:19) INFO: Current date is 2021-11-12
(12:44:19) INFO: Analyzed target //:goimports (0 packages loaded, 0 targets configured).
(12:44:19) INFO: Found 1 target...
Target //:goimports up-to-date:
  bazel-bin/goimports.bash
(12:44:19) INFO: Elapsed time: 0.594s, Critical Path: 0.08s
(12:44:19) INFO: 1 process: 1 internal.
(12:44:19) INFO: Build completed successfully, 1 total action
(12:44:19) INFO: Build completed successfully, 1 total action
err: exit status 1: stderr: unknown command: go. Perhaps you have to reshim?
```

## root cause

for example,  my `PATH` generated by runner.bash is this.

```
'PATH=/Users/xxx/.asdf/shims
/opt/homebrew/Cellar/asdf/0.8.1_1/libexec/bin
/usr/local/bin
/usr/bin
/bin
/usr/sbin
/sbin
/Library/Apple/usr/bin
/opt/homebrew/bin
/opt/homebrew/sbin
/usr/local/opt/mysql-client/bin
...
/private/var/tmp/_bazel_xxx/48e7a5bbefab53edc66892f8661c5731/external/go_sdk/bin'
```

when bazel run goimport , it used `/Users/xxx/.asdf/shims/go` command, which has no goimport. It may be occured by goimport problem (goimport not set specified go binary path)

 - https://cs.opensource.google/go/x/tools/+/refs/tags/v0.1.7:internal/gocommand/invoke.go;l=205

## Solution

I want to use `/private/var/tmp/_bazel_xxx/48e7a5bbefab53edc66892f8661c5731/external/go_sdk/bin/go`  , so switch `PATH` order.