### PR TITLE
Update rules_go to 0.29.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,10 +5,10 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "d1ffd055969c8f8d431e2d439813e42326961d0942bdf734d2c95dc30c369566",
+    sha256 = "d6b2513456fe2229811da7eb67a444be7785f5323c6708b38d851d2b51e54d83",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.24.5/rules_go-v0.24.5.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.24.5/rules_go-v0.24.5.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
     ],
 )
 
@@ -53,7 +53,7 @@ load("//gotemplate:deps.bzl", "gotemplate_dependencies")
 
 go_rules_dependencies()
 
-go_register_toolchains()
+go_register_toolchains("1.17.6")
 
 gazelle_dependencies()
 

--- a/gorevive/example/WORKSPACE
+++ b/gorevive/example/WORKSPACE
@@ -9,8 +9,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "d1ffd055969c8f8d431e2d439813e42326961d0942bdf734d2c95dc30c369566",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.24.5/rules_go-v0.24.5.tar.gz"],
+    sha256 = "d6b2513456fe2229811da7eb67a444be7785f5323c6708b38d851d2b51e54d83",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip"],
 )
 
 http_archive(
@@ -24,7 +24,7 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 
 go_rules_dependencies()
 
-go_register_toolchains()
+go_register_toolchains("1.17.6")
 
 gazelle_dependencies()
 


### PR DESCRIPTION
I'm getting this error locally on an Apple Silicon machine:
```
ERROR: /private/var/tmp/.../external/com_github_ash2k_bazel_tools/multirun/BUILD.bazel:14:10: While resolving toolchains for target @com_github_ash2k_bazel_tools//multirun:multirun: no matching toolchains found for types @io_bazel_rules_go//go:toolchain
```

Given the discussion in https://github.com/bazelbuild/rules_go/issues/2795, the suggested fix is to upgrade rules_go to 0.29.0.