### PR TITLE
set Stdin on exec.Cmd to os.Stdin when running sequentially

### DIFF
--- a/multirun/process.go
+++ b/multirun/process.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"sync"
 	"syscall"
@@ -16,6 +15,7 @@ type process struct {
 	tag string
 	// path is the path of the program to execute.
 	path                   string
+	stdin                  io.Reader
 	stdoutSink, stderrSink io.Writer
 	args                   []string
 	// addTag specifies whether a tag should be prepended to each line on the stdin/stderr from the command.
@@ -27,8 +27,8 @@ func (p *process) run(ctx context.Context) error {
 		Path: p.path,
 		Args: append([]string{p.path}, p.args...),
 		// nil means "use environment of the parent process", see the godoc. We do this explicitly to show the intent.
-		Env: nil,
-		Stdin: os.Stdin,
+		Env:   nil,
+		Stdin: p.stdin,
 	}
 	var stdout, stderr io.ReadCloser
 	if p.addTag {

--- a/multirun/process.go
+++ b/multirun/process.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"sync"
 	"syscall"
@@ -27,6 +28,7 @@ func (p *process) run(ctx context.Context) error {
 		Args: append([]string{p.path}, p.args...),
 		// nil means "use environment of the parent process", see the godoc. We do this explicitly to show the intent.
 		Env: nil,
+		Stdin: os.Stdin,
 	}
 	var stdout, stderr io.ReadCloser
 	if p.addTag {


### PR DESCRIPTION
Fixes https://github.com/ash2k/bazel-tools/issues/25 by setting `Stdin` on `exec.Cmd` to `os.Stdin` 🎉 